### PR TITLE
Fix AND reduction, include cstdint

### DIFF
--- a/include/expression/expression.hpp
+++ b/include/expression/expression.hpp
@@ -158,12 +158,11 @@ class Expression {
 
       if ((lhs_const && lhs_state == State::False) || (rhs_const && rhs_state == State::False)) {
         and_expr.entity_->operator[](idx) = std::make_shared<ConstantEntity>(State::False);
-      } else if ((lhs_const && lhs_state == State::True) ||
-                 (rhs_const && rhs_state == State::True)) {
+      } else if (lhs_const && rhs_const && lhs_state == State::True && rhs_state == State::True) {
         and_expr.entity_->operator[](idx) = std::make_shared<ConstantEntity>(State::True);
-      } else if ((lhs_const && lhs_state == State::True) && !rhs_const) {
+      } else if (lhs_const && lhs_state == State::True && !rhs_const) {
         and_expr.entity_->operator[](idx) = expr.entity_->operator[](idx);
-      } else if (!lhs_const && (rhs_const && rhs_state == State::True)) {
+      } else if (!lhs_const && rhs_const && rhs_state == State::True) {
         and_expr.entity_->operator[](idx) = entity_->operator[](idx);
       } else {
         and_expr.entity_->operator[](idx) =

--- a/include/expression/types.hpp
+++ b/include/expression/types.hpp
@@ -2,6 +2,7 @@
 #define EXPRESSION_TYPES_HPP_
 
 #include <string>
+#include <cstdint>
 
 namespace expression {
 


### PR DESCRIPTION
## Summary
- fix wrong short-circuit in AND expression logic
- include `<cstdint>` for `uint32_t`

## Testing
- `cmake ..` *(fails: Catch2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684907bc188c83209377d6cdb5d51721